### PR TITLE
fix: hot wires staying hot because firefox swallows mouse out events …

### DIFF
--- a/defs_version.go
+++ b/defs_version.go
@@ -4,4 +4,4 @@
 package gostwire
 
 // SemVersion is the semantic version string of the ghostwire module.
-const SemVersion = "2.1.9"
+const SemVersion = "2.1.10-1-gd4c538a"


### PR DESCRIPTION
…instead of correctly sending them.