### PR TITLE
fix: libpod API perf issue due to using /info instead of /_ping (#40)

### DIFF
--- a/decorator/podmannet/_test/pind/Dockerfile
+++ b/decorator/podmannet/_test/pind/Dockerfile
@@ -8,4 +8,17 @@ RUN dnf -y install \
         dnf clean all && \
         rm -rf /var/cache /var/log/dnf* /var/log/yum.* && \
         systemctl enable podman.socket
+RUN echo $'[containers]\n\
+netns="host"\n\
+userns="host"\n\
+ipcns="host"\n\
+utsns="host"\n\
+cgroupns="host"\n\
+cgroups="disabled"\n\
+log_driver = "k8s-file"\n\
+[engine]\n\
+cgroup_manager = "cgroupfs"\n\
+events_logger="file"\n\
+runtime="crun"\n\
+' > /etc/containers/containers.conf
 CMD [ "/usr/sbin/init" ]

--- a/decorator/podmannet/podmannet.go
+++ b/decorator/podmannet/podmannet.go
@@ -53,13 +53,7 @@ func makePodmanNetworks(ctx context.Context, engine *model.ContainerEngine, alln
 			engine.API, err.Error())
 		return
 	}
-	info, err := libpodclient.info(ctx)
-	if err != nil {
-		log.Warnf("cannot discover podman-managed networks from API %s, reason: %s",
-			engine.API, err.Error())
-		return
-	}
-	libpodclient.libpodVersion = info.Version.APIVersion
+	libpodclient.libpodVersion = libpodclient.ping(ctx)
 	networks, _ := libpodclient.networkList(ctx)
 	_ = libpodclient.Close()
 	netnsid, _ := ops.NamespacePath(fmt.Sprintf("/proc/%d/ns/net", engine.PID)).ID()

--- a/decorator/podmannet/podmannet_test.go
+++ b/decorator/podmannet/podmannet_test.go
@@ -13,13 +13,14 @@ import (
 	"github.com/ory/dockertest/v3"
 	"github.com/ory/dockertest/v3/docker"
 	"github.com/siemens/ghostwire/v2/internal/discover"
+	"github.com/siemens/ghostwire/v2/network"
 	"github.com/siemens/turtlefinder"
+	"github.com/thediveo/lxkns/model"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gleak"
 	. "github.com/thediveo/fdooze"
-	"github.com/thediveo/lxkns/model"
 	. "github.com/thediveo/success"
 )
 
@@ -29,8 +30,8 @@ const (
 	pindName      = "ghostwire-pind"
 	pindImageName = "siemens/ghostwire-pind"
 
-	spinupTimeout = 10 * time.Second
-	spinupPolling = 500 * time.Millisecond
+	nifDiscoveryTimeout = 5 * time.Second
+	nifDiscoveryPolling = 250 * time.Millisecond
 
 	goroutinesUnwindTimeout = 2 * time.Second
 	goroutinesUnwindPolling = 250 * time.Millisecond
@@ -92,9 +93,9 @@ var _ = Describe("turtle finder", Ordered, Serial, func() {
 				Repository: pindImageName,
 				Privileged: true,
 				Mounts: []string{
-					"/var", // well, this actually is an unnamed volume
+					"/var/lib/containers", // well, this actually is an unnamed volume
 				},
-				Tty: true,
+				Tty: false,
 			}, func(hc *docker.HostConfig) {
 				hc.Init = false
 				hc.Tmpfs = map[string]string{
@@ -138,7 +139,11 @@ var _ = Describe("turtle finder", Ordered, Serial, func() {
 
 		By("running a canary container connected to the default 'podman' network")
 		Expect(pindCntr.Exec([]string{
-			"podman", "run", "-d", "-it", "--rm", "--name", "canary", "busybox",
+			"podman", "run", "-d", "--rm",
+			"--name", "canary",
+			"--net", "podman", /* WHAT?? otherwise doesn't connect the container??? */
+			"busybox",
+			"/bin/sh", "-c", "while true; do sleep 1; done",
 		}, dockertest.ExecOptions{
 			StdOut: GinkgoWriter,
 			StdErr: GinkgoWriter,
@@ -172,18 +177,12 @@ var _ = Describe("turtle finder", Ordered, Serial, func() {
 		defer cizer.Close()
 
 		By("running a full Ghostwire discovery that should pick up the podman networks")
-		allnetns, lxknsdisco := discover.Discover(ctx, cizer, nil)
-		Expect(lxknsdisco.Processes).To(HaveKey(model.PIDType(pindCntr.Container.State.Pid)))
-		pindNetnsID := lxknsdisco.Processes[model.PIDType(pindCntr.Container.State.Pid)].
-			Namespaces[model.NetNS].ID()
-		Expect(pindNetnsID).NotTo(BeZero())
-		Expect(allnetns).To(HaveKey(pindNetnsID))
-		pindNetns := allnetns[pindNetnsID]
-		// We expect the following network interfaces to be present inside our
-		// podman-in-docker container:
-		//  - eth0 ... a.k.a. the "mcwielahm" network
-		//  - podman0 ... a.k.a. the "podman" network
-		Expect(pindNetns.Nifs).To(ContainElements(
+		Eventually(ctx, func() map[int]network.Interface {
+			allnetns, lxknsdisco := discover.Discover(ctx, cizer, nil)
+			pindNetnsID := lxknsdisco.Processes[model.PIDType(pindCntr.Container.State.Pid)].
+				Namespaces[model.NetNS].ID()
+			return allnetns[pindNetnsID].Nifs
+		}).Within(nifDiscoveryPolling).ProbeEvery(nifDiscoveryPolling).Should(ContainElements(
 			HaveField("Nif()", And(
 				HaveField("Name", "eth0"),
 				HaveField("Alias", "mcwielahm"))),
@@ -191,6 +190,7 @@ var _ = Describe("turtle finder", Ordered, Serial, func() {
 				HaveField("Name", "podman0"),
 				HaveField("Alias", "podman"))),
 		))
+
 	})
 
 })

--- a/defs_version.go
+++ b/defs_version.go
@@ -4,4 +4,4 @@
 package gostwire
 
 // SemVersion is the semantic version string of the ghostwire module.
-const SemVersion = "2.1.18-12-gede2f48"
+const SemVersion = "2.3.0-4-g1927622"


### PR DESCRIPTION
* test: log list-network timing for Docker, podman
* perf: don't use /info libpod endpoint for API version detection, as it is very slow
* fix: use _ping endpoint for libpod API version detection
* chore: refactoring
* fix: podmannet test failing on Ubuntu 22.04LTS
